### PR TITLE
Fix YAML formatting errors

### DIFF
--- a/src/cli.yml
+++ b/src/cli.yml
@@ -5,12 +5,12 @@ author: CodeChain Team <codechain@kodebox.io>
 about: CodeChian Blake Miner
 args:
   - listening port:
-    short: p
-    long: port
-    takes_value: true
-    default_value: "3333"
+      short: p
+      long: port
+      takes_value: true
+      default_value: "3333"
   - submitting port:
-    short: s
-    long: submit
-    takes_value: true
-    default_value: "8080"
+      short: s
+      long: submit
+      takes_value: true
+      default_value: "8080"


### PR DESCRIPTION
The format of yaml file seems to be incorrect when applying the commit below.

https://github.com/CodeChain-io/codechain-blake-miner/commit/59c6aa66bc643d4754cda46a5879f5432ca8e04e#diff-7a605b7f732fd36413a24e50cccc5768L8